### PR TITLE
FEAT: 웹 소켓 클라이언트 설정

### DIFF
--- a/conversation/build.gradle
+++ b/conversation/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'


### PR DESCRIPTION
gpt api 를 위한 웹 소켓 클라이언트를 설정한다.

- [x] 'org.springframework.boot:spring-boot-starter-websocket' 의존성 추가