### PR TITLE
FEAT: GPT REALTIME API 활용을 위한 웹소켓 연결 구현 

### DIFF
--- a/conversation/.gitignore
+++ b/conversation/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+## env ##
+.env

--- a/conversation/build.gradle
+++ b/conversation/build.gradle
@@ -36,3 +36,18 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+
+def envFile = file(".env")
+def envProps = [:]
+if(envFile.exists()){
+	envFile.eachLine {line ->
+		line = line.trim()
+		if(!line || line.startsWith('#')) return
+		def (key, value) = line.split("=", 2)
+		envProps[key] = value
+	}
+}
+
+test{
+	environment envProps
+}

--- a/conversation/src/main/java/me/khw7385/conversation/config/WebSocketClientConfig.java
+++ b/conversation/src/main/java/me/khw7385/conversation/config/WebSocketClientConfig.java
@@ -1,0 +1,14 @@
+package me.khw7385.conversation.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.client.WebSocketClient;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+
+@Configuration
+public class WebSocketClientConfig {
+    @Bean
+    public WebSocketClient webSocketClient(){
+        return new StandardWebSocketClient();
+    }
+}

--- a/conversation/src/main/java/me/khw7385/conversation/infrastructure/OpenAiRealtimeApi.java
+++ b/conversation/src/main/java/me/khw7385/conversation/infrastructure/OpenAiRealtimeApi.java
@@ -1,0 +1,61 @@
+package me.khw7385.conversation.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHttpHeaders;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.client.WebSocketClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+@Component
+@RequiredArgsConstructor
+public class OpenAiRealtimeApi {
+    private static final String OPENAI_REALTIME_WEBSOCKET_URL = "wss://api.openai.com/v1/realtime";
+    private static final String OPENAI_BETA_HEADER = "OpenAI-Beta";
+    private static final String OPENAI_BETA_VALUE = "realtime=v1";
+
+    private static final Integer DELAY_SECONDS = 3;
+
+    @Value("${openai.api-key}")
+    private String OPENAI_API_KEY;
+
+    @Value("${openai.realtime-model}")
+    private String OPENAI_REALTIME_MODEL;
+
+    private final WebSocketClient webSocketClient;
+    private final RealtimeWebSocketHandler webSocketHandler;
+
+    public WebSocketSession openWebSocketSession(){
+        try {
+            return openWebSocketSessionAsync().get(DELAY_SECONDS, TimeUnit.SECONDS);
+        }catch (InterruptedException | ExecutionException | TimeoutException e){
+            // 임시 처리
+            throw new RuntimeException();
+        }
+    }
+
+    private CompletableFuture<WebSocketSession> openWebSocketSessionAsync(){
+        return webSocketClient.execute(webSocketHandler,
+                createHttpHeaders(),
+                UriComponentsBuilder.
+                        fromUriString(OPENAI_REALTIME_WEBSOCKET_URL)
+                        .queryParam("model", OPENAI_REALTIME_MODEL)
+                        .build(true)
+                        .toUri()
+        );
+    }
+
+    private WebSocketHttpHeaders createHttpHeaders(){
+        WebSocketHttpHeaders headers = new WebSocketHttpHeaders();
+        headers.add(HttpHeaders.AUTHORIZATION, String.format("Bearer %s", OPENAI_API_KEY));
+        headers.add(OPENAI_BETA_HEADER, OPENAI_BETA_VALUE);
+        return headers;
+    }
+}

--- a/conversation/src/main/java/me/khw7385/conversation/infrastructure/RealtimeWebSocketHandler.java
+++ b/conversation/src/main/java/me/khw7385/conversation/infrastructure/RealtimeWebSocketHandler.java
@@ -1,0 +1,19 @@
+package me.khw7385.conversation.infrastructure;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.BinaryMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.AbstractWebSocketHandler;
+
+@Component
+public class RealtimeWebSocketHandler extends AbstractWebSocketHandler {
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+        super.afterConnectionEstablished(session);
+    }
+
+    @Override
+    protected void handleBinaryMessage(WebSocketSession session, BinaryMessage message) throws Exception {
+        super.handleBinaryMessage(session, message);
+    }
+}

--- a/conversation/src/main/resources/application.properties
+++ b/conversation/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=conversation

--- a/conversation/src/main/resources/application.yml
+++ b/conversation/src/main/resources/application.yml
@@ -1,0 +1,7 @@
+spring:
+  application:
+    name: conversation
+
+openai:
+  api-key: ${OPENAI_API_KEY}
+  realtime-model: gpt-4o-realtime-preview-2025-06-03

--- a/conversation/src/test/java/me/khw7385/conversation/infrastructure/OpenAiRealtimeApiTest.java
+++ b/conversation/src/test/java/me/khw7385/conversation/infrastructure/OpenAiRealtimeApiTest.java
@@ -1,0 +1,24 @@
+package me.khw7385.conversation.infrastructure;
+
+import me.khw7385.conversation.config.WebSocketClientConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.web.socket.WebSocketSession;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(classes = { WebSocketClientConfig.class, RealtimeWebSocketHandler.class, OpenAiRealtimeApi.class})
+class OpenAiRealtimeApiTest {
+    @Autowired
+    private OpenAiRealtimeApi openAiRealtimeApi;
+
+    @Test
+    @DisplayName("Realtime Api 와 웹 소켓 연결 - 성공")
+    public void openWebSocketSession_success(){
+        WebSocketSession webSocketSession = openAiRealtimeApi.openWebSocketSession();
+
+        assertTrue(webSocketSession.isOpen());
+    }
+}


### PR DESCRIPTION
GPT REALTIME API 활용을 위한 웹 소켓 연결을 구현한다.

- [x] 웹 소켓 클라이언트 객체 빈 등록
- [x] 웹 소켓 연결 구현
- [x] 웹 소켓 연결 테스트
