### PR TITLE
FEAT: Realtime 세션 생성 API 구현

### DIFF
--- a/conversation/src/main/java/me/khw7385/conversation/config/RestClientConfig.java
+++ b/conversation/src/main/java/me/khw7385/conversation/config/RestClientConfig.java
@@ -1,0 +1,27 @@
+package me.khw7385.conversation.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+    @Value("${openai.api-key}")
+    private String apiKey;
+
+    private static final String OPENAI_BASE_URL = "https://api.openai.com/v1";
+
+    @Bean
+    public RestClient restClient(){
+        return RestClient.builder()
+                .baseUrl(OPENAI_BASE_URL)
+                .defaultHeaders(headers -> {
+                    headers.set(HttpHeaders.AUTHORIZATION, String.format("Bearer %s", apiKey));
+                    headers.set(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+                })
+                .build();
+    }
+}

--- a/conversation/src/main/java/me/khw7385/conversation/domain/RealtimeSession.java
+++ b/conversation/src/main/java/me/khw7385/conversation/domain/RealtimeSession.java
@@ -1,0 +1,24 @@
+package me.khw7385.conversation.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+@Builder
+@Getter
+public class RealtimeSession {
+    private String clientId;
+    private LocalDateTime expiresAt;
+
+    public static RealtimeSession of(String clientId, Integer expiresAt){
+        return RealtimeSession.builder()
+                .clientId(clientId)
+                .expiresAt(LocalDateTime.ofInstant(
+                        Instant.ofEpochSecond(expiresAt),
+                        ZoneId.systemDefault()))
+                .build();
+    }
+}

--- a/conversation/src/main/java/me/khw7385/conversation/infrastructure/OpenAiRealtimeApi.java
+++ b/conversation/src/main/java/me/khw7385/conversation/infrastructure/OpenAiRealtimeApi.java
@@ -23,27 +23,24 @@ public class OpenAiRealtimeApi {
 
     private static final Integer DELAY_SECONDS = 3;
 
-    @Value("${openai.api-key}")
-    private String OPENAI_API_KEY;
-
     @Value("${openai.realtime-model}")
     private String OPENAI_REALTIME_MODEL;
 
     private final WebSocketClient webSocketClient;
     private final RealtimeWebSocketHandler webSocketHandler;
 
-    public WebSocketSession openWebSocketSession(){
+    public WebSocketSession openWebSocketSession(String clientId){
         try {
-            return openWebSocketSessionAsync().get(DELAY_SECONDS, TimeUnit.SECONDS);
+            return openWebSocketSessionAsync(clientId).get(DELAY_SECONDS, TimeUnit.SECONDS);
         }catch (InterruptedException | ExecutionException | TimeoutException e){
             // 임시 처리
             throw new RuntimeException();
         }
     }
 
-    private CompletableFuture<WebSocketSession> openWebSocketSessionAsync(){
+    private CompletableFuture<WebSocketSession> openWebSocketSessionAsync(String clientId){
         return webSocketClient.execute(webSocketHandler,
-                createHttpHeaders(),
+                createHttpHeaders(clientId),
                 UriComponentsBuilder.
                         fromUriString(OPENAI_REALTIME_WEBSOCKET_URL)
                         .queryParam("model", OPENAI_REALTIME_MODEL)
@@ -52,9 +49,9 @@ public class OpenAiRealtimeApi {
         );
     }
 
-    private WebSocketHttpHeaders createHttpHeaders(){
+    private WebSocketHttpHeaders createHttpHeaders(String clientId){
         WebSocketHttpHeaders headers = new WebSocketHttpHeaders();
-        headers.add(HttpHeaders.AUTHORIZATION, String.format("Bearer %s", OPENAI_API_KEY));
+        headers.add(HttpHeaders.AUTHORIZATION, String.format("Bearer %s", clientId));
         headers.add(OPENAI_BETA_HEADER, OPENAI_BETA_VALUE);
         return headers;
     }

--- a/conversation/src/main/java/me/khw7385/conversation/infrastructure/OpenAiSessionCreationApi.java
+++ b/conversation/src/main/java/me/khw7385/conversation/infrastructure/OpenAiSessionCreationApi.java
@@ -1,0 +1,37 @@
+package me.khw7385.conversation.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+import me.khw7385.conversation.domain.RealtimeSession;
+import me.khw7385.conversation.infrastructure.request.RealtimeSessionCreateRequest;
+import me.khw7385.conversation.infrastructure.response.RealtimeSessionCreateResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.util.Objects;
+
+@Component
+@RequiredArgsConstructor
+public class OpenAiSessionCreationApi {
+    private static final String REALTIME_SESSION_PATH = "/realtime/sessions";
+
+    @Value("${openai.realtime-model}")
+    private String model;
+
+    private final RestClient restClient;
+
+    public RealtimeSession createSession(){
+        RealtimeSessionCreateResponse response = restClient.post()
+                .uri(REALTIME_SESSION_PATH)
+                .body(RealtimeSessionCreateRequest.of(model))
+                .retrieve()
+                .body(RealtimeSessionCreateResponse.class);
+
+        return map(Objects.requireNonNull(response));
+    }
+
+    private RealtimeSession map(RealtimeSessionCreateResponse response){
+        RealtimeSessionCreateResponse.ClientSecret clientSecret = response.clientSecret();
+        return RealtimeSession.of(clientSecret.value(), clientSecret.expiresAt());
+    }
+}

--- a/conversation/src/main/java/me/khw7385/conversation/infrastructure/request/RealtimeSessionCreateRequest.java
+++ b/conversation/src/main/java/me/khw7385/conversation/infrastructure/request/RealtimeSessionCreateRequest.java
@@ -1,0 +1,34 @@
+package me.khw7385.conversation.infrastructure.request;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record RealtimeSessionCreateRequest(
+        String model,
+        List<String> modalities,
+        String instruction,
+        @JsonProperty("client_secret") ClientSecret clientSecret
+
+) {
+    public static RealtimeSessionCreateRequest of(String model){
+        return RealtimeSessionCreateRequest.builder()
+                .model(model)
+                .modalities(List.of("audio", "text"))
+//                .clientSecret(new ClientSecret(new ClientSecret.ExpiresAt("createdAt", 60)))
+                .build();
+    }
+
+    public record ClientSecret(
+        @JsonProperty("expires_at") ExpiresAt expiresAt
+    ){
+        public record ExpiresAt(
+            String anchor,
+            Integer seconds
+        ){}
+    }
+}

--- a/conversation/src/main/java/me/khw7385/conversation/infrastructure/response/RealtimeSessionCreateResponse.java
+++ b/conversation/src/main/java/me/khw7385/conversation/infrastructure/response/RealtimeSessionCreateResponse.java
@@ -1,0 +1,17 @@
+package me.khw7385.conversation.infrastructure.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record RealtimeSessionCreateResponse(
+        String id,
+        String model,
+        List<String> modalities,
+        @JsonProperty("client_secret") ClientSecret clientSecret
+){
+    public record ClientSecret(
+            String value,
+            @JsonProperty("expires_at") Integer expiresAt){
+    }
+}

--- a/conversation/src/test/java/me/khw7385/conversation/infrastructure/OpenAiRealtimeApiTest.java
+++ b/conversation/src/test/java/me/khw7385/conversation/infrastructure/OpenAiRealtimeApiTest.java
@@ -4,20 +4,26 @@ import me.khw7385.conversation.config.WebSocketClientConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.web.socket.WebSocketSession;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@SpringBootTest(classes = { WebSocketClientConfig.class, RealtimeWebSocketHandler.class, OpenAiRealtimeApi.class})
+@SpringBootTest(classes = {
+        WebSocketClientConfig.class, RealtimeWebSocketHandler.class, OpenAiRealtimeApi.class,
+})
 class OpenAiRealtimeApiTest {
+    @Value("${openai.api-key}")
+    private String apiKey;
     @Autowired
-    private OpenAiRealtimeApi openAiRealtimeApi;
+    private OpenAiRealtimeApi realtimeApi;
 
     @Test
     @DisplayName("Realtime Api 와 웹 소켓 연결 - 성공")
     public void openWebSocketSession_success(){
-        WebSocketSession webSocketSession = openAiRealtimeApi.openWebSocketSession();
+
+        WebSocketSession webSocketSession = realtimeApi.openWebSocketSession(apiKey);
 
         assertTrue(webSocketSession.isOpen());
     }

--- a/conversation/src/test/java/me/khw7385/conversation/infrastructure/OpenAiSessionCreationApiTest.java
+++ b/conversation/src/test/java/me/khw7385/conversation/infrastructure/OpenAiSessionCreationApiTest.java
@@ -1,0 +1,24 @@
+package me.khw7385.conversation.infrastructure;
+
+import me.khw7385.conversation.config.RestClientConfig;
+import me.khw7385.conversation.domain.RealtimeSession;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(classes = {RestClientConfig.class, OpenAiSessionCreationApi.class})
+class OpenAiSessionCreationApiTest {
+
+    @Autowired
+    private OpenAiSessionCreationApi realtimeApi;
+
+    @Test
+    void createSession_success(){
+        RealtimeSession session = realtimeApi.createSession();
+
+        assertNotNull(session.getClientId());
+        assertNotNull(session.getExpiresAt());
+    }
+}


### PR DESCRIPTION
Realtime 세션 생성 API 구현한다.

- [x] RestClient 객체 빈 등록
- [x] 세션 생성 API 구현
- [x] 테스트