### PR TITLE
FEAT: 회화에 대한 도메인 및 저장소를 구현

### DIFF
--- a/conversation/build.gradle
+++ b/conversation/build.gradle
@@ -27,9 +27,11 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	runtimeOnly 'com.h2database:h2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/conversation/src/main/java/me/khw7385/conversation/application/AudioStreamingFacade.java
+++ b/conversation/src/main/java/me/khw7385/conversation/application/AudioStreamingFacade.java
@@ -17,28 +17,29 @@ public class AudioStreamingFacade implements AudioStreamingUseCase {
     private final OpenAiRealtimeApi realtimeApi;
 
     @Override
-    public void connect(String id, MessageChannel clientChannel){
+    public void connect(String channelId, MessageChannel clientChannel){
         MessageChannel aiChannel = realtimeApi.openMessageChannel();
-        channelRegistry.register(id, aiChannel.getId(), clientChannel);
-        channelRegistry.register(aiChannel.getId(), id, aiChannel);
+
+        channelRegistry.register(channelId, aiChannel.getId(), clientChannel);
+        channelRegistry.register(aiChannel.getId(), channelId, aiChannel);
     }
 
     @Override
-    public void forward(String id, Message message){
-        MessageChannel channel = channelRegistry.resolvePairChannel(id).orElseThrow(MessageChannelNotFoundException::new);
+    public void forward(String channelId, Message message){
+        MessageChannel channel = channelRegistry.resolvePairChannel(channelId).orElseThrow(MessageChannelNotFoundException::new);
         channel.sendAudioMessage(message);
     }
 
     @Override
-    public void releaseChannel(String id) {
-        MessageChannel channel = channelRegistry.resolve(id);
-        channelRegistry.unregister(id);
+    public void releaseChannel(String channelId) {
+        MessageChannel channel = channelRegistry.resolve(channelId);
+        channelRegistry.unregister(channelId);
         channel.close();
     }
 
     @Override
-    public void releasePairChannel(String id){
-        channelRegistry.resolvePairChannel(id).ifPresent(channel -> {
+    public void releasePairChannel(String channelId){
+        channelRegistry.resolvePairChannel(channelId).ifPresent(channel -> {
             if(channel.isOpen()) channel.close();
             channelRegistry.unregister(channel.getId());
         });

--- a/conversation/src/main/java/me/khw7385/conversation/application/AudioStreamingFacade.java
+++ b/conversation/src/main/java/me/khw7385/conversation/application/AudioStreamingFacade.java
@@ -2,9 +2,9 @@ package me.khw7385.conversation.application;
 
 import lombok.RequiredArgsConstructor;
 import me.khw7385.conversation.application.port.inbound.AudioStreamingUseCase;
+import me.khw7385.conversation.application.port.outbound.ChannelRegistry;
 import me.khw7385.conversation.application.port.outbound.Message;
 import me.khw7385.conversation.application.port.outbound.MessageChannel;
-import me.khw7385.conversation.application.port.outbound.ChannelRegistry;
 import me.khw7385.conversation.core.exception.MessageChannelNotFoundException;
 import me.khw7385.conversation.infrastructure.OpenAiRealtimeApi;
 import org.springframework.stereotype.Service;
@@ -31,17 +31,13 @@ public class AudioStreamingFacade implements AudioStreamingUseCase {
     }
 
     @Override
-    public void releaseChannel(String channelId) {
-        MessageChannel channel = channelRegistry.resolve(channelId);
-        channelRegistry.unregister(channelId);
-        channel.close();
-    }
+    public void cleanUp(String channelId){
+        channelRegistry.resolve(channelId).ifPresent(channel -> {
+            MessageChannel partnerChannel = channelRegistry.resolvePairChannel(channelId).orElseThrow(MessageChannelNotFoundException::new);
+            channelRegistry.unregister(channelId);
+            channelRegistry.unregister(partnerChannel.getId());
 
-    @Override
-    public void releasePairChannel(String channelId){
-        channelRegistry.resolvePairChannel(channelId).ifPresent(channel -> {
-            if(channel.isOpen()) channel.close();
-            channelRegistry.unregister(channel.getId());
+            if(partnerChannel.isOpen()) partnerChannel.close();
         });
     }
 }

--- a/conversation/src/main/java/me/khw7385/conversation/application/ConversationFacade.java
+++ b/conversation/src/main/java/me/khw7385/conversation/application/ConversationFacade.java
@@ -1,0 +1,21 @@
+package me.khw7385.conversation.application;
+
+import lombok.RequiredArgsConstructor;
+import me.khw7385.conversation.domain.Conversation;
+import me.khw7385.conversation.domain.repository.ConversationRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ConversationFacade {
+    private final ConversationRepository conversationRepository;
+
+    public String findPrompt(Long themeId){
+        Conversation conversation = conversationRepository.findById(themeId)
+                .orElseThrow();
+        return conversation.getPrompt();
+    }
+}

--- a/conversation/src/main/java/me/khw7385/conversation/application/ConversationFacade.java
+++ b/conversation/src/main/java/me/khw7385/conversation/application/ConversationFacade.java
@@ -1,6 +1,7 @@
 package me.khw7385.conversation.application;
 
 import lombok.RequiredArgsConstructor;
+import me.khw7385.conversation.core.exception.ConversationNotFoundException;
 import me.khw7385.conversation.domain.Conversation;
 import me.khw7385.conversation.domain.repository.ConversationRepository;
 import org.springframework.stereotype.Service;
@@ -15,7 +16,7 @@ public class ConversationFacade {
 
     public String findPrompt(Long themeId){
         Conversation conversation = conversationRepository.findById(themeId)
-                .orElseThrow();
+                .orElseThrow(() -> new ConversationNotFoundException(themeId));
         return conversation.getPrompt();
     }
 }

--- a/conversation/src/main/java/me/khw7385/conversation/application/port/inbound/AudioStreamingUseCase.java
+++ b/conversation/src/main/java/me/khw7385/conversation/application/port/inbound/AudioStreamingUseCase.java
@@ -4,8 +4,8 @@ import me.khw7385.conversation.application.port.outbound.Message;
 import me.khw7385.conversation.application.port.outbound.MessageChannel;
 
 public interface AudioStreamingUseCase {
-    void connect(String id, MessageChannel channel);
-    void forward(String id, Message message);
-    void releaseChannel(String id);
-    void releasePairChannel(String id);
+    void connect(String channelId, MessageChannel channel);
+    void forward(String channelId, Message message);
+    void releaseChannel(String channelId);
+    void releasePairChannel(String channelId);
 }

--- a/conversation/src/main/java/me/khw7385/conversation/application/port/inbound/AudioStreamingUseCase.java
+++ b/conversation/src/main/java/me/khw7385/conversation/application/port/inbound/AudioStreamingUseCase.java
@@ -6,6 +6,5 @@ import me.khw7385.conversation.application.port.outbound.MessageChannel;
 public interface AudioStreamingUseCase {
     void connect(String channelId, MessageChannel channel);
     void forward(String channelId, Message message);
-    void releaseChannel(String channelId);
-    void releasePairChannel(String channelId);
+    void cleanUp(String channelId);
 }

--- a/conversation/src/main/java/me/khw7385/conversation/application/port/outbound/ChannelRegistry.java
+++ b/conversation/src/main/java/me/khw7385/conversation/application/port/outbound/ChannelRegistry.java
@@ -4,7 +4,7 @@ import java.util.Optional;
 
 public interface ChannelRegistry {
     void register(String id, String partnerId, MessageChannel channel);
-    MessageChannel resolve(String id);
+    Optional<MessageChannel> resolve(String id);
     Optional<MessageChannel> resolvePairChannel(String id);
     void unregister(String id);
 }

--- a/conversation/src/main/java/me/khw7385/conversation/core/annotation/WebSocketErrorHandling.java
+++ b/conversation/src/main/java/me/khw7385/conversation/core/annotation/WebSocketErrorHandling.java
@@ -1,0 +1,11 @@
+package me.khw7385.conversation.core.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(value = {ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface WebSocketErrorHandling {
+}

--- a/conversation/src/main/java/me/khw7385/conversation/core/aop/WebSocketErrorHandlingAspect.java
+++ b/conversation/src/main/java/me/khw7385/conversation/core/aop/WebSocketErrorHandlingAspect.java
@@ -1,0 +1,30 @@
+package me.khw7385.conversation.core.aop;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.khw7385.conversation.application.port.inbound.AudioStreamingUseCase;
+import me.khw7385.conversation.core.exception.ApplicationException;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketSession;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class WebSocketErrorHandlingAspect {
+    private final AudioStreamingUseCase audioStreamingUseCase;
+
+    @Around("@annotation(me.khw7385.conversation.core.annotation.WebSocketErrorHandling) && args(session, ..)")
+    public Object handleOnError(ProceedingJoinPoint point, WebSocketSession session) throws Throwable{
+        try{
+            return point.proceed();
+        }catch (ApplicationException e){
+            log.error(e.getMessage());
+            audioStreamingUseCase.disconnect(session.getId());
+        }
+        return null;
+    }
+}

--- a/conversation/src/main/java/me/khw7385/conversation/core/aop/WebSocketErrorHandlingAspect.java
+++ b/conversation/src/main/java/me/khw7385/conversation/core/aop/WebSocketErrorHandlingAspect.java
@@ -13,17 +13,14 @@ import org.springframework.web.socket.WebSocketSession;
 @Slf4j
 @Aspect
 @Component
-@RequiredArgsConstructor
 public class WebSocketErrorHandlingAspect {
-    private final AudioStreamingUseCase audioStreamingUseCase;
-
     @Around("@annotation(me.khw7385.conversation.core.annotation.WebSocketErrorHandling) && args(session, ..)")
     public Object handleOnError(ProceedingJoinPoint point, WebSocketSession session) throws Throwable{
         try{
             return point.proceed();
         }catch (ApplicationException e){
             log.error(e.getMessage());
-            audioStreamingUseCase.disconnect(session.getId());
+            session.close();
         }
         return null;
     }

--- a/conversation/src/main/java/me/khw7385/conversation/core/config/AopConfig.java
+++ b/conversation/src/main/java/me/khw7385/conversation/core/config/AopConfig.java
@@ -1,0 +1,9 @@
+package me.khw7385.conversation.core.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+
+@Configuration
+@EnableAspectJAutoProxy
+public class AopConfig {
+}

--- a/conversation/src/main/java/me/khw7385/conversation/core/config/WebSocketServerConfig.java
+++ b/conversation/src/main/java/me/khw7385/conversation/core/config/WebSocketServerConfig.java
@@ -1,6 +1,7 @@
 package me.khw7385.conversation.core.config;
 
 import lombok.RequiredArgsConstructor;
+import me.khw7385.conversation.core.interceptor.WebSocketInterceptor;
 import me.khw7385.conversation.infrastructure.websocket.client.ClientWebSocketHandler;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
@@ -12,9 +13,11 @@ import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry
 @RequiredArgsConstructor
 public class WebSocketServerConfig implements WebSocketConfigurer {
     private final ClientWebSocketHandler clientWebSocketHandler;
+    private final WebSocketInterceptor webSocketInterceptor;
 
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-        registry.addHandler(clientWebSocketHandler, "/conversation/streaming");
+        registry.addHandler(clientWebSocketHandler, "/conversation/streaming")
+                .addInterceptors(webSocketInterceptor);
     }
 }

--- a/conversation/src/main/java/me/khw7385/conversation/core/config/WebSocketServerConfig.java
+++ b/conversation/src/main/java/me/khw7385/conversation/core/config/WebSocketServerConfig.java
@@ -2,8 +2,10 @@ package me.khw7385.conversation.core.config;
 
 import lombok.RequiredArgsConstructor;
 import me.khw7385.conversation.core.interceptor.WebSocketInterceptor;
+import me.khw7385.conversation.infrastructure.websocket.ExceptionHandlingWebSocketHandlerDecorator;
 import me.khw7385.conversation.infrastructure.websocket.client.ClientWebSocketHandler;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.WebSocketHandler;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
@@ -17,7 +19,9 @@ public class WebSocketServerConfig implements WebSocketConfigurer {
 
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-        registry.addHandler(clientWebSocketHandler, "/conversation/streaming")
+        WebSocketHandler handler = new ExceptionHandlingWebSocketHandlerDecorator(clientWebSocketHandler);
+
+        registry.addHandler(handler, "/conversation/streaming")
                 .addInterceptors(webSocketInterceptor);
     }
 }

--- a/conversation/src/main/java/me/khw7385/conversation/core/exception/ApplicationException.java
+++ b/conversation/src/main/java/me/khw7385/conversation/core/exception/ApplicationException.java
@@ -1,0 +1,11 @@
+package me.khw7385.conversation.core.exception;
+
+public class ApplicationException extends RuntimeException{
+    public ApplicationException(String message) {
+        super(message);
+    }
+
+    public String getMessage(){
+        return super.getMessage();
+    }
+}

--- a/conversation/src/main/java/me/khw7385/conversation/core/exception/BusinessException.java
+++ b/conversation/src/main/java/me/khw7385/conversation/core/exception/BusinessException.java
@@ -1,0 +1,7 @@
+package me.khw7385.conversation.core.exception;
+
+public class BusinessException extends ApplicationException{
+    public BusinessException(String message) {
+        super(message);
+    }
+}

--- a/conversation/src/main/java/me/khw7385/conversation/core/exception/ConversationNotFoundException.java
+++ b/conversation/src/main/java/me/khw7385/conversation/core/exception/ConversationNotFoundException.java
@@ -1,0 +1,7 @@
+package me.khw7385.conversation.core.exception;
+
+public class ConversationNotFoundException extends BusinessException {
+    public ConversationNotFoundException(Long id) {
+        super(String.format("해당 id를 가진 Conversation이 존재하지 않습니다. id = %d", id));
+    }
+}

--- a/conversation/src/main/java/me/khw7385/conversation/core/exception/MessageChannelNotFoundException.java
+++ b/conversation/src/main/java/me/khw7385/conversation/core/exception/MessageChannelNotFoundException.java
@@ -1,4 +1,7 @@
 package me.khw7385.conversation.core.exception;
 
-public class MessageChannelNotFoundException extends RuntimeException {
+public class MessageChannelNotFoundException extends BusinessException {
+    public MessageChannelNotFoundException() {
+        super("Message Channel이 존재하지 않습니다.");
+    }
 }

--- a/conversation/src/main/java/me/khw7385/conversation/core/interceptor/WebSocketInterceptor.java
+++ b/conversation/src/main/java/me/khw7385/conversation/core/interceptor/WebSocketInterceptor.java
@@ -1,0 +1,33 @@
+package me.khw7385.conversation.core.interceptor;
+
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.Map;
+
+@Component
+public class WebSocketInterceptor implements HandshakeInterceptor {
+    private static final String THEME_PARAM = "theme";
+
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
+        URI uri = request.getURI();
+
+        MultiValueMap<String, String> params = UriComponentsBuilder.fromUri(uri)
+                .build()
+                .getQueryParams();
+
+        attributes.put("theme", params.getFirst(THEME_PARAM));
+        return true;
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Exception exception) {
+    }
+}

--- a/conversation/src/main/java/me/khw7385/conversation/domain/Conversation.java
+++ b/conversation/src/main/java/me/khw7385/conversation/domain/Conversation.java
@@ -1,0 +1,27 @@
+package me.khw7385.conversation.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Conversation {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String title;
+    private String prompt;
+
+    public static Conversation create(String title, String prompt){
+        return Conversation.builder()
+                .title(title)
+                .prompt(prompt)
+                .build();
+    }
+}

--- a/conversation/src/main/java/me/khw7385/conversation/domain/repository/ConversationRepository.java
+++ b/conversation/src/main/java/me/khw7385/conversation/domain/repository/ConversationRepository.java
@@ -3,7 +3,5 @@ package me.khw7385.conversation.domain.repository;
 import me.khw7385.conversation.domain.Conversation;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface ConversationRepository extends JpaRepository<Conversation, Long> {
 }

--- a/conversation/src/main/java/me/khw7385/conversation/domain/repository/ConversationRepository.java
+++ b/conversation/src/main/java/me/khw7385/conversation/domain/repository/ConversationRepository.java
@@ -1,0 +1,9 @@
+package me.khw7385.conversation.domain.repository;
+
+import me.khw7385.conversation.domain.Conversation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ConversationRepository extends JpaRepository<Conversation, Long> {
+}

--- a/conversation/src/main/java/me/khw7385/conversation/infrastructure/enums/RealtimeEventType.java
+++ b/conversation/src/main/java/me/khw7385/conversation/infrastructure/enums/RealtimeEventType.java
@@ -8,7 +8,9 @@ import java.util.Arrays;
 
 public enum RealtimeEventType {
     // client
-    CLIENT_INPUT_AUDIO_BUFFER_APPEND("input_audio_buffer.append"),
+    SESSION_UPDATE("session.update"),
+
+    INPUT_AUDIO_BUFFER_APPEND("input_audio_buffer.append"),
 
     // server
     ERROR("error"),

--- a/conversation/src/main/java/me/khw7385/conversation/infrastructure/event/ClientWebSocketEventHandler.java
+++ b/conversation/src/main/java/me/khw7385/conversation/infrastructure/event/ClientWebSocketEventHandler.java
@@ -4,16 +4,14 @@ import lombok.RequiredArgsConstructor;
 import me.khw7385.conversation.application.ConversationFacade;
 import me.khw7385.conversation.application.port.inbound.AudioStreamingUseCase;
 import me.khw7385.conversation.application.port.outbound.MessageChannel;
-import me.khw7385.conversation.core.exception.MessageChannelConnectionException;
-import me.khw7385.conversation.core.exception.MessageChannelNotFoundException;
-import me.khw7385.conversation.core.exception.MessageTransferException;
 import me.khw7385.conversation.infrastructure.event.dto.ClientAudioChunkReceivedEvent;
 import me.khw7385.conversation.infrastructure.event.dto.ClientWebSocketClosedEvent;
 import me.khw7385.conversation.infrastructure.event.dto.ClientWebSocketConnectedEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
-import static me.khw7385.conversation.infrastructure.websocket.openai.ServerToAiRealtimeMessage.*;
+import static me.khw7385.conversation.infrastructure.websocket.openai.dto.ServerToAiRealtimeMessage.createAudioAppendMessage;
+import static me.khw7385.conversation.infrastructure.websocket.openai.dto.ServerToAiRealtimeMessage.createSessionUpdateMessage;
 
 @Component
 @RequiredArgsConstructor
@@ -24,27 +22,19 @@ public class ClientWebSocketEventHandler {
     @EventListener
     public void handle(ClientWebSocketConnectedEvent event){
         MessageChannel channel = event.channel();
-        try{
-            audioStreamingUseCase.connect(event.webSocketId(), channel);
+        audioStreamingUseCase.connect(event.webSocketId(), channel);
 
-            String prompt = conversationFacade.findPrompt(event.themeId());
-            audioStreamingUseCase.forward(event.webSocketId(), createSessionUpdateMessage(prompt));
-        }catch(MessageChannelConnectionException e){
-            channel.close();
-        }
+        String prompt = conversationFacade.findPrompt(event.themeId());
+        audioStreamingUseCase.forward(event.webSocketId(), createSessionUpdateMessage(prompt));
     }
 
     @EventListener
     public void handle(ClientAudioChunkReceivedEvent event){
-        try {
-            audioStreamingUseCase.forward(event.webSocketId(), createAudioAppendMessage(event.audio()));
-        }catch(MessageChannelNotFoundException | MessageTransferException e){
-            audioStreamingUseCase.releaseChannel(event.webSocketId());
-        }
+        audioStreamingUseCase.forward(event.webSocketId(), createAudioAppendMessage(event.audio()));
     }
 
     @EventListener
     public void handle(ClientWebSocketClosedEvent event) {
-        audioStreamingUseCase.releasePairChannel(event.webSocketId());
+        audioStreamingUseCase.cleanUp(event.webSocketId());
     }
 }

--- a/conversation/src/main/java/me/khw7385/conversation/infrastructure/event/ClientWebSocketEventHandler.java
+++ b/conversation/src/main/java/me/khw7385/conversation/infrastructure/event/ClientWebSocketEventHandler.java
@@ -1,29 +1,34 @@
 package me.khw7385.conversation.infrastructure.event;
 
 import lombok.RequiredArgsConstructor;
+import me.khw7385.conversation.application.ConversationFacade;
 import me.khw7385.conversation.application.port.inbound.AudioStreamingUseCase;
 import me.khw7385.conversation.application.port.outbound.MessageChannel;
 import me.khw7385.conversation.core.exception.MessageChannelConnectionException;
 import me.khw7385.conversation.core.exception.MessageChannelNotFoundException;
 import me.khw7385.conversation.core.exception.MessageTransferException;
-import me.khw7385.conversation.infrastructure.enums.RealtimeEventType;
 import me.khw7385.conversation.infrastructure.event.dto.ClientAudioChunkReceivedEvent;
 import me.khw7385.conversation.infrastructure.event.dto.ClientWebSocketClosedEvent;
 import me.khw7385.conversation.infrastructure.event.dto.ClientWebSocketConnectedEvent;
-import me.khw7385.conversation.infrastructure.websocket.openai.ServerToAiRealtimeMessage;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
+
+import static me.khw7385.conversation.infrastructure.websocket.openai.ServerToAiRealtimeMessage.*;
 
 @Component
 @RequiredArgsConstructor
 public class ClientWebSocketEventHandler {
     private final AudioStreamingUseCase audioStreamingUseCase;
+    private final ConversationFacade conversationFacade;
 
     @EventListener
     public void handle(ClientWebSocketConnectedEvent event){
         MessageChannel channel = event.channel();
         try{
             audioStreamingUseCase.connect(event.webSocketId(), channel);
+
+            String prompt = conversationFacade.findPrompt(event.themeId());
+            audioStreamingUseCase.forward(event.webSocketId(), createSessionUpdateMessage(prompt));
         }catch(MessageChannelConnectionException e){
             channel.close();
         }
@@ -32,8 +37,7 @@ public class ClientWebSocketEventHandler {
     @EventListener
     public void handle(ClientAudioChunkReceivedEvent event){
         try {
-            audioStreamingUseCase.forward(event.webSocketId(),
-                    ServerToAiRealtimeMessage.of(RealtimeEventType.CLIENT_INPUT_AUDIO_BUFFER_APPEND, event.audio()));
+            audioStreamingUseCase.forward(event.webSocketId(), createAudioAppendMessage(event.audio()));
         }catch(MessageChannelNotFoundException | MessageTransferException e){
             audioStreamingUseCase.releaseChannel(event.webSocketId());
         }

--- a/conversation/src/main/java/me/khw7385/conversation/infrastructure/event/RealtimeWebSocketEventHandler.java
+++ b/conversation/src/main/java/me/khw7385/conversation/infrastructure/event/RealtimeWebSocketEventHandler.java
@@ -2,11 +2,9 @@ package me.khw7385.conversation.infrastructure.event;
 
 import lombok.RequiredArgsConstructor;
 import me.khw7385.conversation.application.port.inbound.AudioStreamingUseCase;
-import me.khw7385.conversation.core.exception.MessageChannelNotFoundException;
-import me.khw7385.conversation.core.exception.MessageTransferException;
 import me.khw7385.conversation.infrastructure.event.dto.RealtimeAudioChunkReceivedEvent;
 import me.khw7385.conversation.infrastructure.event.dto.RealtimeWebSocketClosedEvent;
-import me.khw7385.conversation.infrastructure.websocket.client.ServerToClientAudioMessage;
+import me.khw7385.conversation.infrastructure.websocket.client.dto.ServerToClientAudioMessage;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
@@ -17,15 +15,11 @@ public class RealtimeWebSocketEventHandler {
 
     @EventListener
     public void handle(RealtimeAudioChunkReceivedEvent event){
-        try {
-            audioStreamingUseCase.forward(event.webSocketId(), new ServerToClientAudioMessage(event.audio()));
-        }catch(MessageChannelNotFoundException | MessageTransferException e){
-            audioStreamingUseCase.releaseChannel(event.webSocketId());
-        }
+        audioStreamingUseCase.forward(event.webSocketId(), new ServerToClientAudioMessage(event.audio()));
     }
 
     @EventListener
     public void handle(RealtimeWebSocketClosedEvent event) {
-        audioStreamingUseCase.releasePairChannel(event.webSocketId());
+        audioStreamingUseCase.cleanUp(event.webSocketId());
     }
 }

--- a/conversation/src/main/java/me/khw7385/conversation/infrastructure/event/dto/ClientWebSocketConnectedEvent.java
+++ b/conversation/src/main/java/me/khw7385/conversation/infrastructure/event/dto/ClientWebSocketConnectedEvent.java
@@ -4,6 +4,7 @@ import me.khw7385.conversation.application.port.outbound.MessageChannel;
 
 public record ClientWebSocketConnectedEvent(
         String webSocketId,
-        MessageChannel channel
+        MessageChannel channel,
+        Long themeId
 ) {
 }

--- a/conversation/src/main/java/me/khw7385/conversation/infrastructure/init/ConversationInitializer.java
+++ b/conversation/src/main/java/me/khw7385/conversation/infrastructure/init/ConversationInitializer.java
@@ -1,0 +1,28 @@
+package me.khw7385.conversation.infrastructure.init;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import me.khw7385.conversation.domain.repository.ConversationRepository;
+import org.springframework.stereotype.Component;
+
+import static me.khw7385.conversation.domain.Conversation.*;
+
+@Component
+@RequiredArgsConstructor
+public class ConversationInitializer {
+    private final ConversationRepository conversationRepository;
+
+    @PostConstruct
+    public void init(){
+        conversationRepository.save(
+                create(
+                        "패스트 푸드점에서 대화하기",
+                        """
+                        Let's do a role-play.
+                        You can pretend to be a fast food clerk.
+                        You don't have to ask me questions all the time.
+                        Try to keep the conversation as realistic as possible. Response are made in less than 200 characters.
+                        """
+                        ));
+    }
+}

--- a/conversation/src/main/java/me/khw7385/conversation/infrastructure/init/ConversationInitializer.java
+++ b/conversation/src/main/java/me/khw7385/conversation/infrastructure/init/ConversationInitializer.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 import me.khw7385.conversation.domain.repository.ConversationRepository;
 import org.springframework.stereotype.Component;
 
-import static me.khw7385.conversation.domain.Conversation.*;
+import static me.khw7385.conversation.domain.Conversation.create;
 
 @Component
 @RequiredArgsConstructor

--- a/conversation/src/main/java/me/khw7385/conversation/infrastructure/websocket/ExceptionHandlingWebSocketHandlerDecorator.java
+++ b/conversation/src/main/java/me/khw7385/conversation/infrastructure/websocket/ExceptionHandlingWebSocketHandlerDecorator.java
@@ -1,0 +1,36 @@
+package me.khw7385.conversation.infrastructure.websocket;
+
+import lombok.extern.slf4j.Slf4j;
+import me.khw7385.conversation.core.exception.ApplicationException;
+import me.khw7385.conversation.infrastructure.websocket.client.ClientWebSocketHandler;
+import org.springframework.web.socket.WebSocketMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.WebSocketHandlerDecorator;
+
+@Slf4j
+public class ExceptionHandlingWebSocketHandlerDecorator extends WebSocketHandlerDecorator {
+    public ExceptionHandlingWebSocketHandlerDecorator(ClientWebSocketHandler delegate) {
+        super(delegate);
+    }
+
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+        try {
+            super.afterConnectionEstablished(session);
+        }catch(ApplicationException e){
+            log.error(e.getMessage());
+            session.close();
+        }
+    }
+
+    @Override
+    public void handleMessage(WebSocketSession session, WebSocketMessage<?> message) throws Exception {
+        try{
+            super.handleMessage(session, message);
+        }catch(ApplicationException e){
+            log.error(e.getMessage());
+            session.close();
+        }
+    }
+}
+

--- a/conversation/src/main/java/me/khw7385/conversation/infrastructure/websocket/InMemoryChannelRegistry.java
+++ b/conversation/src/main/java/me/khw7385/conversation/infrastructure/websocket/InMemoryChannelRegistry.java
@@ -1,8 +1,8 @@
 package me.khw7385.conversation.infrastructure.websocket;
 
 import lombok.extern.slf4j.Slf4j;
-import me.khw7385.conversation.application.port.outbound.MessageChannel;
 import me.khw7385.conversation.application.port.outbound.ChannelRegistry;
+import me.khw7385.conversation.application.port.outbound.MessageChannel;
 import org.springframework.stereotype.Component;
 
 import java.util.Optional;
@@ -22,8 +22,8 @@ public class InMemoryChannelRegistry implements ChannelRegistry {
     }
 
     @Override
-    public MessageChannel resolve(String id){
-        return channelStore.get(id);
+    public Optional<MessageChannel> resolve(String id){
+        return Optional.ofNullable(channelStore.get(id));
     }
 
     @Override
@@ -34,8 +34,9 @@ public class InMemoryChannelRegistry implements ChannelRegistry {
 
     @Override
     public void unregister(String id) {
+        log.info("메시지 채널 제거: id = {}", id);
+
         channelStore.remove(id);
         partnerStore.remove(id);
-        log.info("메시지 채널 제거: channelId = {}", id);
     }
 }

--- a/conversation/src/main/java/me/khw7385/conversation/infrastructure/websocket/client/ClientWebSocketHandler.java
+++ b/conversation/src/main/java/me/khw7385/conversation/infrastructure/websocket/client/ClientWebSocketHandler.java
@@ -4,9 +4,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import me.khw7385.conversation.infrastructure.event.dto.ClientAudioChunkReceivedEvent;
-import me.khw7385.conversation.infrastructure.event.dto.ClientWebSocketConnectedEvent;
 import me.khw7385.conversation.infrastructure.event.dto.ClientWebSocketClosedEvent;
+import me.khw7385.conversation.infrastructure.event.dto.ClientWebSocketConnectedEvent;
 import me.khw7385.conversation.infrastructure.websocket.MessageChannelFactory;
+import me.khw7385.conversation.infrastructure.websocket.client.dto.ClientToServerAudioMessage;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.CloseStatus;
@@ -23,6 +24,7 @@ public class ClientWebSocketHandler extends AbstractWebSocketHandler {
     private final ObjectMapper objectMapper;
 
     @Override
+//    @WebSocketErrorHandling
     public void afterConnectionEstablished(WebSocketSession session){
         Long themeId = Long.parseLong((String)session.getAttributes().get("theme"));
 
@@ -31,9 +33,13 @@ public class ClientWebSocketHandler extends AbstractWebSocketHandler {
     }
 
     @Override
+//    @WebSocketErrorHandling
     protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
         ClientToServerAudioMessage request = objectMapper.readValue(message.getPayload(), ClientToServerAudioMessage.class);
-        eventPublisher.publishEvent(new ClientAudioChunkReceivedEvent(session.getId(), request.audio()));
+
+        if(session.isOpen()){
+            eventPublisher.publishEvent(new ClientAudioChunkReceivedEvent(session.getId(), request.audio()));
+        }
     }
 
     @Override

--- a/conversation/src/main/java/me/khw7385/conversation/infrastructure/websocket/client/ClientWebSocketHandler.java
+++ b/conversation/src/main/java/me/khw7385/conversation/infrastructure/websocket/client/ClientWebSocketHandler.java
@@ -24,8 +24,10 @@ public class ClientWebSocketHandler extends AbstractWebSocketHandler {
 
     @Override
     public void afterConnectionEstablished(WebSocketSession session){
+        Long themeId = Long.parseLong((String)session.getAttributes().get("theme"));
+
         log.info("Client WebSocket 연결 성공: session id = {}", session.getId());
-        eventPublisher.publishEvent(new ClientWebSocketConnectedEvent(session.getId(), messageChannelFactory.create(session)));
+        eventPublisher.publishEvent(new ClientWebSocketConnectedEvent(session.getId(), messageChannelFactory.create(session), themeId));
     }
 
     @Override

--- a/conversation/src/main/java/me/khw7385/conversation/infrastructure/websocket/client/dto/ClientToServerAudioMessage.java
+++ b/conversation/src/main/java/me/khw7385/conversation/infrastructure/websocket/client/dto/ClientToServerAudioMessage.java
@@ -1,4 +1,4 @@
-package me.khw7385.conversation.infrastructure.websocket.client;
+package me.khw7385.conversation.infrastructure.websocket.client.dto;
 
 public record ClientToServerAudioMessage(
         String audio

--- a/conversation/src/main/java/me/khw7385/conversation/infrastructure/websocket/client/dto/ServerToClientAudioMessage.java
+++ b/conversation/src/main/java/me/khw7385/conversation/infrastructure/websocket/client/dto/ServerToClientAudioMessage.java
@@ -1,4 +1,4 @@
-package me.khw7385.conversation.infrastructure.websocket.client;
+package me.khw7385.conversation.infrastructure.websocket.client.dto;
 
 import me.khw7385.conversation.application.port.outbound.Message;
 

--- a/conversation/src/main/java/me/khw7385/conversation/infrastructure/websocket/openai/RealtimeWebSocketHandler.java
+++ b/conversation/src/main/java/me/khw7385/conversation/infrastructure/websocket/openai/RealtimeWebSocketHandler.java
@@ -3,9 +3,11 @@ package me.khw7385.conversation.infrastructure.websocket.openai;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import me.khw7385.conversation.core.annotation.WebSocketErrorHandling;
 import me.khw7385.conversation.infrastructure.enums.RealtimeEventType;
 import me.khw7385.conversation.infrastructure.event.dto.RealtimeAudioChunkReceivedEvent;
 import me.khw7385.conversation.infrastructure.event.dto.RealtimeWebSocketClosedEvent;
+import me.khw7385.conversation.infrastructure.websocket.openai.dto.AiToServerRealtimeMessage;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.CloseStatus;
@@ -21,16 +23,18 @@ public class RealtimeWebSocketHandler extends AbstractWebSocketHandler {
     private final ObjectMapper objectMapper;
 
     @Override
+    @WebSocketErrorHandling
     public void afterConnectionEstablished(WebSocketSession session) throws Exception {
         log.info("Realtime WebSocket 연걸 성공: session id = {}", session.getId());
     }
 
     @Override
+    @WebSocketErrorHandling
     protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
         AiToServerRealtimeMessage response = objectMapper.readValue(message.getPayload(), AiToServerRealtimeMessage.class);
         log.info("메시지 이벤트 타입: {}", response.type().getValue());
 
-        if (response.type().equals(RealtimeEventType.RESPONSE_AUDIO_DELTA)) {
+        if (session.isOpen() && response.type().equals(RealtimeEventType.RESPONSE_AUDIO_DELTA)) {
             eventPublisher.publishEvent(new RealtimeAudioChunkReceivedEvent(session.getId(), response.delta()));
         }
     }

--- a/conversation/src/main/java/me/khw7385/conversation/infrastructure/websocket/openai/ServerToAiRealtimeMessage.java
+++ b/conversation/src/main/java/me/khw7385/conversation/infrastructure/websocket/openai/ServerToAiRealtimeMessage.java
@@ -6,17 +6,32 @@ import lombok.Builder;
 import me.khw7385.conversation.application.port.outbound.Message;
 import me.khw7385.conversation.infrastructure.enums.RealtimeEventType;
 
+import static me.khw7385.conversation.infrastructure.enums.RealtimeEventType.*;
+
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record ServerToAiRealtimeMessage(
         @JsonProperty("event_id") String eventId,
         RealtimeEventType type,
-        String audio
+        String audio,
+        Session session
 ) implements Message{
-    public static ServerToAiRealtimeMessage of(RealtimeEventType type, String base64chunk){
+    public static ServerToAiRealtimeMessage createAudioAppendMessage(String base64chunk){
         return ServerToAiRealtimeMessage.builder()
-                .type(type)
+                .type(INPUT_AUDIO_BUFFER_APPEND)
                 .audio(base64chunk)
                 .build();
+    }
+
+    public static ServerToAiRealtimeMessage createSessionUpdateMessage(String instructions){
+        return ServerToAiRealtimeMessage.builder()
+                .type(SESSION_UPDATE)
+                .session(new Session(instructions))
+                .build();
+    }
+
+    private record Session(
+            String instructions
+    ){
     }
 }

--- a/conversation/src/main/java/me/khw7385/conversation/infrastructure/websocket/openai/dto/AiToServerRealtimeMessage.java
+++ b/conversation/src/main/java/me/khw7385/conversation/infrastructure/websocket/openai/dto/AiToServerRealtimeMessage.java
@@ -1,4 +1,4 @@
-package me.khw7385.conversation.infrastructure.websocket.openai;
+package me.khw7385.conversation.infrastructure.websocket.openai.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import me.khw7385.conversation.infrastructure.enums.RealtimeEventType;

--- a/conversation/src/main/java/me/khw7385/conversation/infrastructure/websocket/openai/dto/ServerToAiRealtimeMessage.java
+++ b/conversation/src/main/java/me/khw7385/conversation/infrastructure/websocket/openai/dto/ServerToAiRealtimeMessage.java
@@ -1,4 +1,4 @@
-package me.khw7385.conversation.infrastructure.websocket.openai;
+package me.khw7385.conversation.infrastructure.websocket.openai.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -6,7 +6,8 @@ import lombok.Builder;
 import me.khw7385.conversation.application.port.outbound.Message;
 import me.khw7385.conversation.infrastructure.enums.RealtimeEventType;
 
-import static me.khw7385.conversation.infrastructure.enums.RealtimeEventType.*;
+import static me.khw7385.conversation.infrastructure.enums.RealtimeEventType.INPUT_AUDIO_BUFFER_APPEND;
+import static me.khw7385.conversation.infrastructure.enums.RealtimeEventType.SESSION_UPDATE;
 
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/conversation/src/main/resources/application.yml
+++ b/conversation/src/main/resources/application.yml
@@ -1,6 +1,18 @@
 spring:
   application:
     name: conversation
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;MODE=MySQL
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
 
 openai:
   api-key: ${OPENAI_API_KEY}


### PR DESCRIPTION
회화에 대한 도메인 및 저장소를 구현한다.
Open AI 와의 웹소켓 연결 시 해당 회화 주제에 맞는 프롬프트를 조회해 세션을 설정한다.

- [x] h2 인 메모리 DB 환경 구성
- [x] Conversation 도메인 및 레포지토리 구현
- [x] 비즈니스 예외 처리를 위해 AOP 와 웹 소켓 데코레이터 활용
- [x] 웹 소켓 close 이후 메시지 처리 오류 해결